### PR TITLE
Change path to caddy binary

### DIFF
--- a/systemd/caddy.service
+++ b/systemd/caddy.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 User=caddy
 LimitNOFILE=4096
-ExecStart=/opt/caddy/caddy -agree=true -conf=/etc/caddy/Caddyfile -pidfile=/var/run/caddy/caddy.pid -log=stderr
+ExecStart=/usr/local/bin/caddy -agree=true -conf=/etc/caddy/Caddyfile -pidfile=/var/run/caddy/caddy.pid -log=stderr
 PIDFile=/var/run/caddy/caddy.pid
 Restart=on-failure
 


### PR DESCRIPTION
I have not seen anyone put caddy at /opt/caddy/caddy, and getcaddy.com follows /usr/local/bin as well