### PR TITLE
Add Nextcloud example

### DIFF
--- a/nextcloud/Caddyfile
+++ b/nextcloud/Caddyfile
@@ -1,0 +1,43 @@
+my-nextcloud-site.com {
+
+	root   /var/www/nextcloud
+	log    /var/log/nextcloud_access.log
+	errors /var/log/nextcloud_errors.log
+
+	fastcgi / 127.0.0.1:9000 php {
+		env PATH /bin
+	}
+
+	rewrite {
+		r ^/index.php/.*$
+		to /index.php?{query}
+	}
+
+	# client support (e.g. os x calendar / contacts)
+	redir /.well-known/carddav /remote.php/carddav 301
+	redir /.well-known/caldav /remote.php/caldav 301
+
+	# remove trailing / as it causes errors with php-fpm
+	rewrite {
+		r ^/remote.php/(webdav|caldav|carddav|dav)(\/?)$
+		to /remote.php/{1}
+	}
+
+	rewrite {
+		r ^/remote.php/(webdav|caldav|carddav|dav)/(.+?)(\/?)$
+		to /remote.php/{1}/{2}
+	}
+
+	# .htaccess / data / config / ... shouldn't be accessible from outside
+	status 403 {
+		/.htacces
+		/data
+		/config
+		/db_structure
+		/.xml
+		/README
+	}
+
+	header / Strict-Transport-Security "max-age=31536000;"
+
+}

--- a/nextcloud/README.md
+++ b/nextcloud/README.md
@@ -1,0 +1,8 @@
+# Nextcloud
+
+This is an example configuration of how to use [Nextcloud](https://nextcloud.com/) with caddy.
+
+The configuration is based on [this](https://caddyserver.com/blog/caddy_and_owncloud) blog post.
+
+## Notes
+* PHP-FPM requests are accepted on a TCP sockets instead of a Unix socket for optimal integration with caddy. To achieve this replace `listen = /run/php/php7.0-fpm.soc` to `listen = 127.0.0.1:9000` in `/etc/php/7.0/fpm/pool.d/www.conf` on Ubuntu 14.04.


### PR DESCRIPTION
The config is based on [this](https://caddyserver.com/blog/caddy_and_owncloud) post from the caddy blog. I wondered why it’s missing from this examples repo so I added it with some changes like the new `status`-directive and the change to nextcloud.