### PR TITLE
Kirby fix: allow public access to panel js, css, etc.

### DIFF
--- a/kirby/Caddyfile_root
+++ b/kirby/Caddyfile_root
@@ -28,6 +28,7 @@ rewrite {
 
 # panel links
 rewrite /panel {
+  if {path} not_match /panel/assets/.*
   to {uri} /panel/index.php?{path}&{query}
 }
 

--- a/kirby/Caddyfile_subdir
+++ b/kirby/Caddyfile_subdir
@@ -30,6 +30,7 @@ rewrite /kirby-test {
 
 # panel links
 rewrite /kirby-test/panel {
+  if {path} not_match /panel/assets/.*
   to {uri} /kirby-test/panel/index.php?{path}&{query}
 }
 


### PR DESCRIPTION
The Kirby admin panel didn't load any js, css or font files under `/panel/assets`. They were rewritten to `panel/index.php` too, so I added an exception for that. I'm not an expert, but I think everything under `/panel/assets` is only public files.

There's still the problem that going to `localhost:8080/panel` shows the error page, but going to `localhost:8080/panel/` shows the proper panel login page, so it seems that the rewrite only works when there's the trailing slash. Any idea hot to have the rewrite apply without the slash too?