### PR TITLE
disable timeout on git clone for gitea service

### DIFF
--- a/gitea/Caddyfile
+++ b/gitea/Caddyfile
@@ -1,3 +1,5 @@
 mygitea.com {
-    proxy / localhost:3000
+  # Please disable timeout if error: RPC failed; curl 18 transfer closed with outstanding read data remaining
+  # timeout 0
+  proxy / localhost:3000
 }


### PR DESCRIPTION
error: RPC failed; curl 18 transfer closed with outstanding read data remaining