### PR TITLE
Disable timeout for minio proxy

### DIFF
--- a/minio/Caddyfile
+++ b/minio/Caddyfile
@@ -2,6 +2,10 @@ your.public.com
 
 proxy / localhost:9000 {
     transparent
+    timeouts {
+        read none
+        write none
+    }
 }
 
 


### PR DESCRIPTION
With caddy version 0.9.5 timeouts are now enabled by default (https://github.com/mholt/caddy/releases/tag/v0.9.5). This breaks uploads and downloads with minio that take longer then 10s.