### PR TITLE
Updated Caddyfile for Seafile

### DIFF
--- a/seafile/Caddyfile
+++ b/seafile/Caddyfile
@@ -2,10 +2,16 @@ example.com {
     proxy / localhost:8000 {
         transparent
     }
+    gzip
 }
-
 example.com/seafhttp {
     proxy / localhost:8082 {
+        without /seafhttp
         transparent
     }
+    gzip
+}
+example.com/media {
+    root /home/user/haiwen/seafile-server-latest/seahub/media
+    gzip
 }


### PR DESCRIPTION
Updated config file to more closely match Seafile's documentation. This would close https://github.com/caddyserver/examples/issues/44

'without' trims the /seafhttp prefix from requests, like the regexp in Seafile's example nginx config: https://manual.seafile.com/deploy/https_with_nginx.html

Also included /media folder for static serving. This could alternatively be done with root and except directives in the first domain block.

gzip for good measure