### PR TITLE
Update Gitlab example for Caddy v0.10

### DIFF
--- a/gitlab/Caddyfile
+++ b/gitlab/Caddyfile
@@ -10,5 +10,6 @@ https://gitlab.example.com {
     proxy / http://127.0.0.1:8181 {
         fail_timeout 300s
         transparent
+        header_upstream X-Forwarded-Ssl on
     }
 }

--- a/gitlab/Caddyfile
+++ b/gitlab/Caddyfile
@@ -9,10 +9,6 @@ https://gitlab.example.com {
 
     proxy / http://127.0.0.1:8181 {
         fail_timeout 300s
-
-        header_upstream Host {host}
-        header_upstream X-Real-IP {remote}
-        header_upstream X-Forwarded-Proto {scheme}
-        header_upstream X-Forwarded-Ssl on
+        transparent
     }
 }

--- a/gitlab/Caddyfile
+++ b/gitlab/Caddyfile
@@ -1,10 +1,6 @@
 https://gitlab.example.com {
-    log git.access.log {
-        rotate
-    }
-
-    errors {
-        log git.errors.log
+    log git.access.log 
+    errors git.errors.log {
         404 /opt/gitlab/embedded/service/gitlab-rails/public/404.html
         422 /opt/gitlab/embedded/service/gitlab-rails/public/422.html
         500 /opt/gitlab/embedded/service/gitlab-rails/public/500.html
@@ -14,9 +10,9 @@ https://gitlab.example.com {
     proxy / http://127.0.0.1:8181 {
         fail_timeout 300s
 
-        proxy_header Host {host}
-        proxy_header X-Real-IP {remote}
-        proxy_header X-Forwarded-Proto {scheme}
-        proxy_header X-Forwarded-Ssl on
+        header_upstream Host {host}
+        header_upstream X-Real-IP {remote}
+        header_upstream X-Forwarded-Proto {scheme}
+        header_upstream X-Forwarded-Ssl on
     }
 }


### PR DESCRIPTION
Logs automatically rotate, error log format updated to move log file outside of {} and "proxy_header" was replaced with "header_upstream"