### PR TITLE
gitlab: Use UNIX socket

### DIFF
--- a/gitlab/Caddyfile-socket
+++ b/gitlab/Caddyfile-socket
@@ -11,6 +11,5 @@ https://gitlab.domain.tld {
         fail_timeout 300s
 
 	transparent
-	header_upstream X-Forwarded-Ssl on
     }
 }

--- a/gitlab/Caddyfile-socket
+++ b/gitlab/Caddyfile-socket
@@ -1,10 +1,5 @@
-https://dev.sth.se.k0nsl.org {
+https://gitlab.domain.tld {
 
-    log git.access.log {
-        rotate_size 50 # Rotate after 50 MB
-        rotate_age  80 # Keep rotated files for 90 days	
-        rotate_keep 15 # Keep at most 20 log files
-    }
     errors {
         404 /opt/gitlab/embedded/service/gitlab-rails/public/404.html
         422 /opt/gitlab/embedded/service/gitlab-rails/public/422.html
@@ -19,6 +14,6 @@ https://dev.sth.se.k0nsl.org {
 	header_upstream X-Real-IP {remote}
 	header_upstream X-Forwarded-For {remote}
 	header_upstream X-Forwarded-Proto {scheme}
-  header_upstream X-Forwarded-Ssl on
+	header_upstream X-Forwarded-Ssl on
     }
 }

--- a/gitlab/Caddyfile-socket
+++ b/gitlab/Caddyfile-socket
@@ -10,10 +10,7 @@ https://gitlab.domain.tld {
     proxy / unix:/home/git/gitlab/tmp/sockets/gitlab.socket {
         fail_timeout 300s
 
-	header_upstream Host {host}
-	header_upstream X-Real-IP {remote}
-	header_upstream X-Forwarded-For {remote}
-	header_upstream X-Forwarded-Proto {scheme}
+	transparent
 	header_upstream X-Forwarded-Ssl on
     }
 }

--- a/gitlab/Caddyfile-socket
+++ b/gitlab/Caddyfile-socket
@@ -1,0 +1,24 @@
+https://dev.sth.se.k0nsl.org {
+
+    log git.access.log {
+        rotate_size 50 # Rotate after 50 MB
+        rotate_age  80 # Keep rotated files for 90 days	
+        rotate_keep 15 # Keep at most 20 log files
+    }
+    errors {
+        404 /opt/gitlab/embedded/service/gitlab-rails/public/404.html
+        422 /opt/gitlab/embedded/service/gitlab-rails/public/422.html
+        500 /opt/gitlab/embedded/service/gitlab-rails/public/500.html
+        502 /opt/gitlab/embedded/service/gitlab-rails/public/502.html
+    }
+
+    proxy / unix:/home/git/gitlab/tmp/sockets/gitlab.socket {
+        fail_timeout 300s
+
+	header_upstream Host {host}
+	header_upstream X-Real-IP {remote}
+	header_upstream X-Forwarded-For {remote}
+	header_upstream X-Forwarded-Proto {scheme}
+  header_upstream X-Forwarded-Ssl on
+    }
+}


### PR DESCRIPTION
This example uses UNIX socket rather than TCP which could benefit performance. I am using this exact configuration on my GitLab server (described with more details here: https://blog.k0nsl.org/2017/04/29/a-note-on-gitlab-with-caddy/)