### PR TITLE
Define shopware.php as index for fastcgi

### DIFF
--- a/shopware/Caddyfile
+++ b/shopware/Caddyfile
@@ -1,6 +1,8 @@
 DOMAIN {
     root /PATH/TO/ROOT-DIR
-    fastcgi / /PATH/TO/FPM-SOCKET php
+    fastcgi / /PATH/TO/FPM-SOCKET php {
+        index shopware.php
+    }
     internal /PATH/TO/X-ACCELERATION-URL/FOR/FILE/DOWNLOADS
     status 404 {
         /autoload.php


### PR DESCRIPTION
The current example does not work if you browse the shop without a path. This fix sets the index file to `shopware.php` which will then show the frontend if you simply open `https://shop.com`.