### PR TITLE
Update Django example for Caddy v0.10

### DIFF
--- a/django/Caddyfile
+++ b/django/Caddyfile
@@ -1,9 +1,6 @@
 domain.tld {
-	proxy / localhost:8000 {
-		proxy_header Host {host}
-		proxy_header X-Forwarded-Proto {scheme}
-		except /media /static
-	}
-
-	root /var/www/project/folder
+    root /var/www/project/folder
+    proxy / localhost:8000 {
+        transparent
+    }
 }


### PR DESCRIPTION
proxy_header is deprecated and not supported in Caddy version 0.10.

The official Caddy documentation recommends using the shorthand transparent when dealing
with proxies.

Resolves: #68