### PR TITLE
Drupal 7 example conf file

### DIFF
--- a/drupal/Drupal7-Caddyfile
+++ b/drupal/Drupal7-Caddyfile
@@ -1,0 +1,36 @@
+# Change this to your web site URL.
+https://localhost:8080
+
+# Set the document root of the site.
+# e.g /var/www/example.com for UNIX/Mac systems.
+root W:\localhost\d7
+
+# Set the path to the php-fpm process.
+fastcgi / 127.0.0.1:9000 php
+
+# This rewrite it to prevent access dot files and folders such
+# as .htaccess, .git, etc.
+rewrite {
+  if {path} starts_with .
+  if {path} not_starts_with .well-known
+  to error/index.html
+}
+
+# This rewrite it to prevent access to raw files with certain extensions.
+rewrite {
+  if {path} match .(bak|config|sql|fla|psd|ini|log|sh|inc|swp|dist|engine|inc|info|install|make|module|profile|test|po|sh|sql|theme|tpl|tpl.php|xtmpl|sw|bak|orig|save)$
+  to error/index.html
+}
+status 404 error/index.html
+
+# Main rewrite to route non-existent files to index.php file.
+rewrite {
+  if {file} not favicon.ico
+  to {path} {path}/ /index.php?{path}&{query}
+}
+
+header / {
+  X-Content-Type-Options nosniff
+}
+
+gzip

--- a/drupal/README.md
+++ b/drupal/README.md
@@ -1,0 +1,10 @@
+
+Run a Drupal sites on Caddy
+---------------------------
+Drupal ♥️ Caddy
+
+Example Caddy configuration file to get started with Caddy.
+There are rewrites to block access module files, SQL files, and several other extensions that should not be accessible via the web server. It also blocks access to dot files. 
+
+You will need to change the site URL, root, and php-fpm information for this to work.
+


### PR DESCRIPTION
Hi Matt,
I have been trying out Caddy for some time, and I couldn't be happier. Thanks for the awesome work!

I could not find a Caddyfile for Drupal, and I could put together a working configuration file. This is not a 100% translation of the Apache `.htaccess` provided with it, but gets the work done. Some of the .htaccess directives were necessary for Caddy (for example setting explicit `Content-Encoding` headers for `gz` files). 

Please review if you have some time, and let me know if any further changes are necessary. 
Cheers!