### PR TITLE
Nextcloud Caddyfile doesn't allow to use public sharing by link

### DIFF
--- a/nextcloud/Caddyfile
+++ b/nextcloud/Caddyfile
@@ -28,6 +28,11 @@ my-nextcloud-site.com {
 		to /remote.php/{1}/{2}
 	}
 
+	rewrite {
+		r ^/public.php/(.+?)(\/?)$
+		to /public.php/(.+?)(\/?)$
+	}
+
 	# .htaccess / data / config / ... shouldn't be accessible from outside
 	status 403 {
 		/.htacces


### PR DESCRIPTION
This PR fixes it.

Without these changes filelist interface is loaded, but files list itself is missing.