### PR TITLE
Added rewrite for images in Nextcloud

### DIFF
--- a/nextcloud/Caddyfile
+++ b/nextcloud/Caddyfile
@@ -7,6 +7,13 @@ my-nextcloud-site.com {
 	fastcgi / 127.0.0.1:9000 php {
 		env PATH /bin
 	}
+	
+	# checks for images
+        rewrite {
+	        ext .svg .gif .png .html .ttf .woff .ico .jpg .jpeg
+		r ^/index.php/(.+)$
+		to /{1} /index.php?{1}
+	}
 
 	rewrite {
 		r ^/index.php/.*$


### PR DESCRIPTION
Some of the images where not loading, so i translated with help a missing nginx `try_files` to caddy syntax.
See https://caddy.community/t/remove-index-php-from-uri-rewrite/2895