### PR TITLE
Nextcloud: fix rewrite for remote shares

### DIFF
--- a/nextcloud/Caddyfile
+++ b/nextcloud/Caddyfile
@@ -36,8 +36,13 @@ my-nextcloud-site.com {
 	}
 
 	rewrite {
-		r ^/public.php/(.+?)(\/?)$
-		to /public.php/(.+?)(\/?)$
+		r ^/public.php/(dav|webdav|caldav|carddav)(\/?)$
+		to /public.php/{1}
+	}
+
+	rewrite {
+		r ^/public.php/(dav|webdav|caldav|carddav)/(.+)(\/?)$
+		to /public.php/{1}/{2}
 	}
 
 	# .htaccess / data / config / ... shouldn't be accessible from outside


### PR DESCRIPTION
While the last added public rewrite might have fixed the issue with accessing public download links, it wasn't possible for remote users to get proper download links at all.

With the rewrite before, it was possible to reach the list of files on a remote folder, but trying to download files causes a moderate flood of requests on both ends due to Nextcloud being eager to find the file that is requested.

These two rewrites fix the issue and make remote sharing work fine.