### PR TITLE
Fix base rewrite for phabricator

### DIFF
--- a/phabricator/Caddyfile
+++ b/phabricator/Caddyfile
@@ -1,6 +1,9 @@
 https://domain.io {
 	root /home/user/phabricator/webroot
-	rewrite / /index.php?__path__=/
+	rewrite {
+                if {path} is /
+                to /index.php?__path__=/
+        }
 	rewrite  {
 		to {path} {path}/ /index.php?__path__={path_escaped}&{query}
 	}


### PR DESCRIPTION
The version in the repo rewrites every single request URI as /index.php?__path__=/, this version will function properly with both the root URL on a domain and all subpages.