### PR TITLE
Fix trailing slash

### DIFF
--- a/nextcloud/Caddyfile
+++ b/nextcloud/Caddyfile
@@ -26,22 +26,22 @@ my-nextcloud-site.com {
 
 	# remove trailing / as it causes errors with php-fpm
 	rewrite {
-		r ^/remote.php/(webdav|caldav|carddav|dav)(\/?)$
+		r ^/remote.php/(webdav|caldav|carddav|dav)(\/?)(\/?)$
 		to /remote.php/{1}
 	}
 
 	rewrite {
-		r ^/remote.php/(webdav|caldav|carddav|dav)/(.+?)(\/?)$
+		r ^/remote.php/(webdav|caldav|carddav|dav)/(.+?)(\/?)(\/?)$
 		to /remote.php/{1}/{2}
 	}
 
 	rewrite {
-		r ^/public.php/(dav|webdav|caldav|carddav)(\/?)$
+		r ^/public.php/(dav|webdav|caldav|carddav)(\/?)(\/?)$
 		to /public.php/{1}
 	}
 
 	rewrite {
-		r ^/public.php/(dav|webdav|caldav|carddav)/(.+)(\/?)$
+		r ^/public.php/(dav|webdav|caldav|carddav)/(.+)(\/?)(\/?)$
 		to /public.php/{1}/{2}
 	}
 


### PR DESCRIPTION
This is what finally fixed my nextcloud not syncing with the desktop client. Maybe it sometimes uses URLs with double trailing slashes?