### PR TITLE
Nextcloud: Update Caddyfile for Nextcloud 14

### DIFF
--- a/nextcloud/Caddyfile
+++ b/nextcloud/Caddyfile
@@ -1,3 +1,4 @@
+
 my-nextcloud-site.com {
 
 	root   /var/www/nextcloud
@@ -7,7 +8,12 @@ my-nextcloud-site.com {
 	fastcgi / 127.0.0.1:9000 php {
 		env PATH /bin
 	}
-	
+
+	header / {
+		 Referrer-Policy		   no-referrer
+		 Strict-Transport-Security	   "max-age=15768000;"
+	}
+
 	# checks for images
         rewrite {
 	        ext .svg .gif .png .html .ttf .woff .ico .jpg .jpeg
@@ -54,7 +60,5 @@ my-nextcloud-site.com {
 		/.xml
 		/README
 	}
-
-	header / Strict-Transport-Security "max-age=31536000;"
 
 }


### PR DESCRIPTION
Nextcloud 14 will show a warning on the Administration page if 'Referrer Policy' is not set.
Updated Caddyfile to include explicit setting for Referrer Policy to make warning go away.

Also updated Strict Transport Security to bring it in line with what Nextcloud suggests.