### PR TITLE
Update gzip rule on Caddyfile for Drone 1.0

### DIFF
--- a/drone/Caddyfile
+++ b/drone/Caddyfile
@@ -1,6 +1,6 @@
 example.com {
     gzip {
-        not /stream/
+        not /api/
     }
     proxy / localhost:8000 {
         websocket


### PR DESCRIPTION
Drone 1.0 is almost done, and the gzip rule:

```
...
gzip {
    not /stream/
}
```

needs to be changed to:

```
...
gzip {
    not /api/
}
```

Drone 1.0 is an RC1 version, so you may want to wait until it reaches the 1.0 final to merge.