### PR TITLE
Radicale2.0 example

### DIFF
--- a/radicale/Caddyfile
+++ b/radicale/Caddyfile
@@ -2,5 +2,7 @@ https://dav.example.org {
     proxy / localhost:5232/ {
         transparent
         header_upstream X-Script-Name /
+        # uncomment and adjust the following line if you want to serve radicale>2.0 in a path below "/"
+        # without /path_below
     }
 }

--- a/radicale/README.md
+++ b/radicale/README.md
@@ -12,4 +12,5 @@ Radicale will be available directly at https://dav.example.org/.
 
 If you want Radicale to be served at a path below `/`, you need to
 adjust the [`X-Script-Name`](https://radicale.org/proxy/) header in
-the [CaddyFile](./Caddyfile).
+the [CaddyFile](./Caddyfile) and since radicale V2.0 you need to 
+adjust the `without` rule as well.


### PR DESCRIPTION
Since Radicale 2.0 we have to "remove the location from the URL path that is forwarded to Radicale" by the proxy (if not "/") [link](https://radicale.org/proxy/). 
This pull request updates the radicale example with the `without` rule that can do that if needed.