### PR TITLE
Added Collabora (CODE)

### DIFF
--- a/collabora/Caddyfile
+++ b/collabora/Caddyfile
@@ -1,0 +1,40 @@
+collabora.example.com {
+    # Static html, js, images, etc. served from loolwsd
+    # Loleaflet is the client part of LibreOffice Online
+    proxy /loleaflet https://collabora:9980 {
+        insecure_skip_verify
+        transparent
+    }
+
+    # WOPI discovery URL
+    proxy /hosting/discovery https://collabora:9980 {
+        insecure_skip_verify
+        transparent
+    }
+
+    # Main websocket
+    proxy /lool https://collabora:9980 {
+        insecure_skip_verify
+        transparent
+        websocket
+    }
+
+    ## Admin console websocket
+    #proxy /lool/adminws https://collabora:9980 {
+    #   insecure_skip_verify
+    #   transparent
+    #   websocket
+    #}
+
+    # Show capabilities as json
+    proxy /hosting/capabilities https://collabora:9980 {
+        insecure_skip_verify
+        transparent
+    }
+
+    # Download as, fullscreen presentation and image upload operations
+    proxy /lool https://collabora:9980 {
+        insecure_skip_verify
+        transparent
+    }
+}

--- a/collabora/README.md
+++ b/collabora/README.md
@@ -1,0 +1,7 @@
+# Collabora CODE
+
+This is an example configuration of how to use [Collabora CODE](https://www.collaboraoffice.com/code/) with caddy.
+
+Collabora can then be used with, for exmaple, [Nextcloud](https://nextcloud.com/).
+
+Note: In this example file Collabora CODE is started using its [official docker container](https://hub.docker.com/r/collabora/code/) and reachable in the internal network using https://collabora:9980.


### PR DESCRIPTION
This Pull Request adds an example to use Collabora (CODE) with caddy. Collabora can then be used with, e.g., [Nextcloud](https://nextcloud.com/collaboraonline/).