### PR TITLE
Changed gunicorn command to be correct for Flask

### DIFF
--- a/flask/README.md
+++ b/flask/README.md
@@ -9,7 +9,7 @@ At the moment, Caddy doesn't support the uwsgi protocol, however check [this iss
 
 2. Launch Gunicorn:
 
-    `gunicorn -b "127.0.0.1:8000" project.wsgi`
+    `gunicorn -b "127.0.0.1:8000" MODULE_NAME:app`
 
     Usually, you will have your Gunicorn script on a supervisor, or 
     something else


### PR DESCRIPTION
The gunicorn command was written to run a django app, a Flask app uses the MODULE_NAME:app pattern instead of something.wsgi.

See [here](http://docs.gunicorn.org/en/stable/run.html#gunicorn) for a Flask example and [here](http://docs.gunicorn.org/en/stable/run.html#gunicorn) for a django example